### PR TITLE
Use real url for GoCardless hyper schema

### DIFF
--- a/schemas/gocardless-hyper-schema.json
+++ b/schemas/gocardless-hyper-schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://schema.gocardless.io/hyper-schema#",
-  "id": "http://schema.gocardless.io/hyper-schema#",
+  "$schema": "https://developer.gocardless.com/hyper-schema.json#",
+  "id": "https://developer.gocardless.com/hyper-schema.json#",
   "title": "GoCardless JSON Hyper-Schema",
   "allOf": [
     {


### PR DESCRIPTION
Omfg the GoCardless hyper schema has a real URL now. Need to test that this legit works before deploying.
